### PR TITLE
XCode 6.3 has changed some method's definition, so some parameters must be changed before compiling.

### DIFF
--- a/Localisation Demo/AppDelegate.swift
+++ b/Localisation Demo/AppDelegate.swift
@@ -14,7 +14,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication!, didFinishLaunchingWithOptions launchOptions: NSDictionary!) -> Bool {
+//  func application(application: UIApplication!, didFinishLaunchingWithOptions launchOptions: NSDictionary!) -> Bool {
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject : AnyObject]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }


### PR DESCRIPTION
XCode 6.3 has changed some method's definition, so some parameters must be changed before compiling.
